### PR TITLE
Handle 'cached_content' in request body prioritization logic.

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -379,8 +379,6 @@ def _transform_request_body(
             data["safetySettings"] = safety_settings
         if generation_config is not None:
             data["generationConfig"] = generation_config
-        if cached_content is not None:
-            data["cachedContent"] = cached_content
     except Exception as e:
         raise e
 


### PR DESCRIPTION
Vertex has a limitation that if we send the cached_content to not have the tools, system_instructions, and tool_config so if it's present we don't add them and if it isn't we add those params