### PR TITLE
Bugfix/pass hosted tools in anthropic streaming

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -431,6 +431,7 @@ class CustomStreamWrapper:
             finish_reason = None
             logprobs = None
             usage = None
+            thinking_blocks = None
 
             if str_line and str_line.choices and len(str_line.choices) > 0:
                 if (
@@ -459,10 +460,17 @@ class CustomStreamWrapper:
                     logprobs = str_line.choices[0].logprobs
                 else:
                     logprobs = None
+                
+                # Preserve thinking_blocks if present in delta
+                if (
+                    hasattr(str_line.choices[0].delta, "thinking_blocks")
+                    and str_line.choices[0].delta.thinking_blocks is not None
+                ):
+                    thinking_blocks = str_line.choices[0].delta.thinking_blocks
 
             usage = getattr(str_line, "usage", None)
 
-            return {
+            result = {
                 "text": text,
                 "is_finished": is_finished,
                 "finish_reason": finish_reason,
@@ -470,6 +478,11 @@ class CustomStreamWrapper:
                 "original_chunk": str_line,
                 "usage": usage,
             }
+            
+            if thinking_blocks is not None:
+                result["thinking_blocks"] = thinking_blocks
+            
+            return result
         except Exception as e:
             raise e
 
@@ -745,6 +758,10 @@ class CustomStreamWrapper:
                 and model_response.choices[0].delta.annotations is not None
             )
             or response_obj.get("usage") is not None
+            or (
+                "thinking_blocks" in response_obj
+                and response_obj["thinking_blocks"] is not None
+            )
         ):
             return True
         else:
@@ -784,12 +801,23 @@ class CustomStreamWrapper:
                                     choice_json.pop(
                                         "finish_reason", None
                                     )  # for mistral etc. which return a value in their last chunk (not-openai compatible).
+                                    
+                                    # Preserve thinking_blocks from the choice_json if present
+                                    # Check if delta exists and has thinking_blocks
+                                    if 'delta' in choice_json and isinstance(choice_json['delta'], dict):
+                                        delta_dict = choice_json['delta']
+                                        # thinking_blocks should already be in the delta dict from model_dump()
+                                        # but let's ensure it's preserved
+                                        if 'thinking_blocks' in delta_dict and delta_dict['thinking_blocks'] is not None:
+                                            print_verbose(f"Preserving thinking_blocks: {delta_dict['thinking_blocks']}")
+                                    
                                     print_verbose(f"choice_json: {choice_json}")
                                     choices.append(StreamingChoices(**choice_json))
                             except Exception:
                                 choices.append(StreamingChoices())
                         print_verbose(f"choices in streaming: {choices}")
                         setattr(model_response, "choices", choices)
+                        
                     else:
                         return
                     model_response.system_fingerprint = (
@@ -804,12 +832,24 @@ class CustomStreamWrapper:
                     if self.sent_first_chunk is False:
                         model_response.choices[0].delta["role"] = "assistant"
                         self.sent_first_chunk = True
+                        
+                        # Preserve thinking_blocks from response_obj if present
+                        if response_obj.get("thinking_blocks") is not None:
+                            # Get the current delta dict
+                            delta_dict = model_response.choices[0].delta.model_dump() if hasattr(model_response.choices[0].delta, "model_dump") else {}
+                            delta_dict["thinking_blocks"] = response_obj["thinking_blocks"]
+                            model_response.choices[0].delta = Delta(**delta_dict)
                     elif self.sent_first_chunk is True and hasattr(
                         model_response.choices[0].delta, "role"
                     ):
                         _initial_delta = model_response.choices[0].delta.model_dump()
 
                         _initial_delta.pop("role", None)
+                        
+                        # Preserve thinking_blocks from response_obj if present
+                        if response_obj.get("thinking_blocks") is not None:
+                            _initial_delta["thinking_blocks"] = response_obj["thinking_blocks"]
+                            
                         model_response.choices[0].delta = Delta(**_initial_delta)
                     verbose_logger.debug(
                         f"model_response.choices[0].delta: {model_response.choices[0].delta}"
@@ -824,6 +864,11 @@ class CustomStreamWrapper:
                         completion_obj["provider_specific_fields"] = response_obj[
                             "provider_specific_fields"
                         ]
+                    
+                    # Preserve thinking_blocks from response_obj if present
+                    if response_obj.get("thinking_blocks") is not None:
+                        completion_obj["thinking_blocks"] = response_obj["thinking_blocks"]
+                    
                     model_response.choices[0].delta = Delta(**completion_obj)
                     _index: Optional[int] = completion_obj.get("index")
                     if _index is not None:
@@ -1055,7 +1100,20 @@ class CustomStreamWrapper:
                     ].items():
                         setattr(model_response, key, value)
 
+                # Preserve thinking_blocks if present
+                if (
+                    "thinking_blocks" in anthropic_response_obj
+                    and anthropic_response_obj["thinking_blocks"] is not None
+                ):
+                    response_obj["thinking_blocks"] = anthropic_response_obj["thinking_blocks"]
+
                 response_obj = cast(Dict[str, Any], anthropic_response_obj)
+                
+                # Also check if thinking_blocks are in the Delta for OpenRouter and other providers
+                if hasattr(model_response, 'choices') and len(model_response.choices) > 0:
+                    delta = model_response.choices[0].delta
+                    if hasattr(delta, 'thinking_blocks') and delta.thinking_blocks is not None:
+                        response_obj["thinking_blocks"] = delta.thinking_blocks
             elif self.model == "replicate" or self.custom_llm_provider == "replicate":
                 response_obj = self.handle_replicate_chunk(chunk)
                 completion_obj["content"] = response_obj["text"]
@@ -1274,7 +1332,22 @@ class CustomStreamWrapper:
                     if isinstance(chunk, BaseModel) and hasattr(chunk, "model"):
                         # for azure, we need to pass the model from the orignal chunk
                         self.model = getattr(chunk, "model", self.model)
+                
+                # For OpenRouter, capture thinking_blocks from model_response BEFORE calling handle_openai_chat_completion_chunk
+                # This happens when the provider-specific chunk_parser creates them
+                thinking_blocks_to_preserve = None
+                if self.custom_llm_provider == "openrouter" and hasattr(model_response, 'choices') and len(model_response.choices) > 0:
+                    delta = model_response.choices[0].delta
+                    if hasattr(delta, 'thinking_blocks') and delta.thinking_blocks is not None:
+                        thinking_blocks_to_preserve = delta.thinking_blocks
+                
                 response_obj = self.handle_openai_chat_completion_chunk(chunk)
+                
+                # Add preserved thinking_blocks to response_obj so chunk isn't dropped
+                if thinking_blocks_to_preserve is not None:
+                    if response_obj is None:
+                        response_obj = {}
+                    response_obj["thinking_blocks"] = thinking_blocks_to_preserve
                 if response_obj is None:
                     return
                 completion_obj["content"] = response_obj["text"]

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -752,6 +752,25 @@ class ModelResponseIterator:
                         },
                         "index": self.tool_index,
                     }
+                elif content_block_start["content_block"]["type"] == "server_tool_use":
+                    # Handle server tool use (e.g., web search) in content block start
+                    content_block = content_block_start["content_block"]
+                    provider_specific_fields["server_tool_use"] = content_block
+                    
+                    self.tool_index += 1
+                    tool_use = {
+                        "id": content_block.get("id"),
+                        "type": "function",
+                        "function": {
+                            "name": content_block.get("name"),
+                            "arguments": json.dumps(content_block.get("input", {})),
+                        },
+                        "index": self.tool_index,
+                    }
+                elif content_block_start["content_block"]["type"] == "web_search_tool_result":
+                    # Handle web search tool result in content block start
+                    content_block = content_block_start["content_block"]
+                    provider_specific_fields["web_search_tool_result"] = content_block
                 elif (
                     content_block_start["content_block"]["type"] == "redacted_thinking"
                 ):

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -40,7 +40,6 @@ from litellm.types.llms.openai import (
     ChatCompletionRedactedThinkingBlock,
     ChatCompletionThinkingBlock,
     ChatCompletionToolCallChunk,
-    ChatCompletionToolCallFunctionChunk,
 )
 from litellm.types.utils import (
     Delta,
@@ -636,25 +635,25 @@ class ModelResponseIterator:
             text = content_block["delta"]["text"]
         elif "partial_json" in content_block["delta"]:
             if self.current_server_tool_id:
-                tool_use = ChatCompletionToolCallChunk(
-                    id=self.current_server_tool_id,
-                    type="function", 
-                    function=ChatCompletionToolCallFunctionChunk(
-                        name=self.current_server_tool_name,
-                        arguments=content_block["delta"]["partial_json"],
-                    ),
-                    index=self.tool_index,
-                )
+                tool_use = {
+                    "id": self.current_server_tool_id,
+                    "type": "function",
+                    "function": {
+                        "name": self.current_server_tool_name,
+                        "arguments": content_block["delta"]["partial_json"],
+                    },
+                    "index": self.tool_index,
+                }
             else:
-                tool_use = ChatCompletionToolCallChunk(
-                    id=None,
-                    type="function",
-                    function=ChatCompletionToolCallFunctionChunk(
-                        name=None,
-                        arguments=content_block["delta"]["partial_json"],
-                    ),
-                    index=self.tool_index,
-                )
+                tool_use = {
+                    "id": None,
+                    "type": "function",
+                    "function": {
+                        "name": None,
+                        "arguments": content_block["delta"]["partial_json"],
+                    },
+                    "index": self.tool_index,
+                }
         elif "citation" in content_block["delta"]:
             provider_specific_fields["citation"] = content_block["delta"]["citation"]
         elif (
@@ -775,15 +774,15 @@ class ModelResponseIterator:
                     self.current_server_tool_name = content_block.get("name")
                     
                     self.tool_index += 1
-                    tool_use = ChatCompletionToolCallChunk(
-                        id=content_block.get("id"),
-                        type="function",
-                        function=ChatCompletionToolCallFunctionChunk(
-                            name=content_block.get("name"),
-                            arguments="",  # Empty for server tool use - arguments will be streamed
-                        ),
-                        index=self.tool_index,
-                    )
+                    tool_use = {
+                        "id": content_block.get("id"),
+                        "type": "function",
+                        "function": {
+                            "name": content_block.get("name"),
+                            "arguments": "",  # Empty for server tool use - arguments will be streamed
+                        },
+                        "index": self.tool_index,
+                    }
                 elif content_block_start["content_block"]["type"] == "web_search_tool_result":
                     # Handle web search tool result in content block start
                     content_block = content_block_start["content_block"]

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -134,11 +134,18 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
                         "reasoning"
                     )
 
-                    if hasattr(delta, "reasoning_details") and delta.reasoning_details:
-                        if hasattr(delta.reasoning_details, "type") and delta.reasoning_details.type == 'reasoning.text':
-                            first_thinking_block = delta.reasoning_details[0]
-                            if 'signature' in first_thinking_block:
-                                choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block['signature']
+                    # Process reasoning_details safely
+                    print(f"Choice: {choice}")
+                    reasoning_details = choice["delta"].get("reasoning_details")
+                    if reasoning_details and isinstance(reasoning_details, list) and len(reasoning_details) > 0:
+                        first_thinking_block = reasoning_details[0]
+                        if (isinstance(first_thinking_block, dict) and 
+                            first_thinking_block.get("type") == "reasoning.text" and
+                            "signature" in first_thinking_block):
+                            # Initialize thinking_blocks if it doesn't exist
+                            if "thinking_blocks" not in choice["delta"]:
+                                choice["delta"]["thinking_blocks"] = {}
+                            choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block["signature"]
 
                     delta = Delta(**choice["delta"])
 

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -134,11 +134,17 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
                         "reasoning"
                     )
 
-                    if hasattr(delta, "reasoning_details") and delta.reasoning_details:
-                        if hasattr(delta.reasoning_details, "type") and delta.reasoning_details.type == 'reasoning.text':
-                            first_thinking_block = delta.reasoning_details[0]
-                            if 'signature' in first_thinking_block:
-                                choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block['signature']
+                    # Process reasoning_details safely
+                    reasoning_details = choice["delta"].get("reasoning_details")
+                    if reasoning_details and isinstance(reasoning_details, list) and len(reasoning_details) > 0:
+                        first_thinking_block = reasoning_details[0]
+                        if (isinstance(first_thinking_block, dict) and 
+                            first_thinking_block.get("type") == "reasoning.text" and
+                            "signature" in first_thinking_block):
+                            # Initialize thinking_blocks if it doesn't exist
+                            if "thinking_blocks" not in choice["delta"]:
+                                choice["delta"]["thinking_blocks"] = {}
+                            choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block["signature"]
 
                     delta = Delta(**choice["delta"])
 

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -120,12 +120,26 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
             finish_reason = None
             delta = Delta()
             logprobs = None
+            # {"id":"gen-1751968953-WEWmZEtpfjrIpGHVkLxh","provider":"Google",
+            # "model":"anthropic/claude-sonnet-4","object":"chat.completion.chunk",
+            # "created":1751968953,"choices":[{"index":0,
+            # "delta":{"role":"assistant","content":"","reasoning":null,"reasoning_details":
+            # [{"type":"reasoning.text","signature":"VkQnK3sSOCidzuDxlxmd003R3QYAQ==","provider":"google-vertex"}]}
+            # ,"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
             if "choices" in chunk and len(chunk["choices"]) > 0:
                 choice = chunk["choices"][0]
                 if "delta" in choice and choice["delta"] is not None:
                     choice["delta"]["reasoning_content"] = choice["delta"].get(
                         "reasoning"
                     )
+
+                    if hasattr(delta, "reasoning_details") and delta.reasoning_details:
+                        if hasattr(delta.reasoning_details, "type") and delta.reasoning_details.type == 'reasoning.text':
+                            first_thinking_block = delta.reasoning_details[0]
+                            if 'signature' in first_thinking_block:
+                                choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block['signature']
+
                     delta = Delta(**choice["delta"])
 
                 if "finish_reason" in choice:

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -134,17 +134,11 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
                         "reasoning"
                     )
 
-                    # Process reasoning_details safely
-                    reasoning_details = choice["delta"].get("reasoning_details")
-                    if reasoning_details and isinstance(reasoning_details, list) and len(reasoning_details) > 0:
-                        first_thinking_block = reasoning_details[0]
-                        if (isinstance(first_thinking_block, dict) and 
-                            first_thinking_block.get("type") == "reasoning.text" and
-                            "signature" in first_thinking_block):
-                            # Initialize thinking_blocks if it doesn't exist
-                            if "thinking_blocks" not in choice["delta"]:
-                                choice["delta"]["thinking_blocks"] = {}
-                            choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block["signature"]
+                    if hasattr(delta, "reasoning_details") and delta.reasoning_details:
+                        if hasattr(delta.reasoning_details, "type") and delta.reasoning_details.type == 'reasoning.text':
+                            first_thinking_block = delta.reasoning_details[0]
+                            if 'signature' in first_thinking_block:
+                                choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block['signature']
 
                     delta = Delta(**choice["delta"])
 

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -135,17 +135,33 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
                     )
 
                     # Process reasoning_details safely
-                    print(f"Choice: {choice}")
                     reasoning_details = choice["delta"].get("reasoning_details")
-                    if reasoning_details and isinstance(reasoning_details, list) and len(reasoning_details) > 0:
-                        first_thinking_block = reasoning_details[0]
-                        if (isinstance(first_thinking_block, dict) and 
-                            first_thinking_block.get("type") == "reasoning.text" and
-                            "signature" in first_thinking_block):
-                            # Initialize thinking_blocks if it doesn't exist
-                            if "thinking_blocks" not in choice["delta"]:
-                                choice["delta"]["thinking_blocks"] = {}
-                            choice["delta"]["thinking_blocks"]["signature"] = first_thinking_block["signature"]
+                    if reasoning_details and isinstance(reasoning_details, list):
+                        # Initialize thinking_blocks as a list if it doesn't exist
+                        if "thinking_blocks" not in choice["delta"]:
+                            choice["delta"]["thinking_blocks"] = []
+                        
+                        # Look for signature in reasoning_details
+                        signature = None
+                        text_content = ""
+                        
+                        for detail in reasoning_details:
+                            if isinstance(detail, dict):
+                                # Check if this detail has a signature
+                                if "signature" in detail and detail["signature"]:
+                                    signature = detail["signature"]
+                                # Check if this detail has text content
+                                if detail.get("type") == "reasoning.text" and detail.get("text"):
+                                    text_content = detail["text"]
+                        
+                        # If we found a signature, create a thinking block
+                        if signature:
+                            thinking_block = {
+                                "type": "thinking", 
+                                "thinking": text_content,
+                                "signature": signature
+                            }
+                            choice["delta"]["thinking_blocks"].append(thinking_block)
 
                     delta = Delta(**choice["delta"])
 


### PR DESCRIPTION
## Fix Anthropic web search response preservation

**Problem**: LiteLLM was dropping Anthropic's web search data (`server_tool_use` + `web_search_tool_result`) when transforming to OpenAI format.

**Fix**: 
- Added missing content type handlers in both streaming and non-streaming modes
- Fixed tool call accumulation during streaming  
- Added test case

**Files changed**:
- `litellm/llms/anthropic/chat/transformation.py` - handle new content types in `extract_response_content()`
- `litellm/llms/anthropic/chat/handler.py` - add `server_tool_use`/`web_search_tool_result` handlers
- `tests/llm_translation/test_anthropic_completion.py` - add `test_anthropic_web_search_streaming()`

Now web search tool calls and results are properly preserved in `tool_calls` and `provider_specific_fields`.